### PR TITLE
Use LinkedList for toBeVisited variable in src/Layout.js file

### DIFF
--- a/src/Layout.js
+++ b/src/Layout.js
@@ -6,6 +6,7 @@ var LGraph = require('./LGraph');
 var PointD = require('./util/PointD');
 var Transform = require('./util/Transform');
 var Emitter = require('./util/Emitter');
+var LinkedList = require('./util/LinkedList');
 
 function Layout(isRemoteUse) {
   Emitter.call( this );
@@ -97,7 +98,7 @@ Layout.prototype.checkLayoutSuccess = function() {
 Layout.prototype.runLayout = function ()
 {
   this.isLayoutFinished = false;
-  
+
   if (this.tilingPreLayout) {
     this.tilingPreLayout();
   }
@@ -113,13 +114,13 @@ Layout.prototype.runLayout = function ()
   {
     isLayoutSuccessfull = this.layout();
   }
-  
+
   if (LayoutConstants.ANIMATE === 'during') {
-    // If this is a 'during' layout animation. Layout is not finished yet. 
+    // If this is a 'during' layout animation. Layout is not finished yet.
     // We need to perform these in index.js when layout is really finished.
     return false;
   }
-  
+
   if (isLayoutSuccessfull)
   {
     if (!this.isSubLayout)
@@ -375,7 +376,7 @@ Layout.prototype.getFlatForest = function ()
   // Run BFS for each component of the graph.
 
   var visited = new Set();
-  var toBeVisited = [];
+  var toBeVisited = new LinkedList();
   var parents = new Map();
   var unProcessedNodes = [];
 
@@ -391,11 +392,9 @@ Layout.prototype.getFlatForest = function ()
 
     // Start the BFS. Each iteration of this loop visits a node in a
     // BFS manner.
-    while (toBeVisited.length > 0 && isForest)
+    while (toBeVisited.size() > 0 && isForest)
     {
-      //pool operation
-      var currentNode = toBeVisited[0];
-      toBeVisited.splice(0, 1);
+      var currentNode = toBeVisited.shift();
       visited.add(currentNode);
 
       // Traverse all neighbors of this node


### PR DESCRIPTION
I recognized that while porting this code from Java, we used a Javascript array instead of the LinkedList for the ``toBeVisited`` variable that is defined as a LinkedList here (https://github.com/iVis-at-Bilkent/chilay/blob/605e77732a6f06da2081e2d89a68084c1e508cdb/src/main/java/org/ivis/layout/Layout.java#L566) in original Java code. However, since there is a ``poll()`` operation performed on the ``toBeVisited`` variable here (https://github.com/iVis-at-Bilkent/chilay/blob/605e77732a6f06da2081e2d89a68084c1e508cdb/src/main/java/org/ivis/layout/Layout.java#L584) using an array must decrease the performance. I think that while porting the code, we used the array there just as a result of a little confusion.

This PR updates the code to define and use ``toBeVisited`` variable as a LinkedList instead of the array. I recognized that in the past a similar fix/update has been done in this commit (https://github.com/cytoscape/cytoscape.js-cose-bilkent/commit/a158455a6cb1ef477251861e0057754e2af0c068) as well.

**Important Note**
**I had issue in running ``npm install``. Therefore, I could not test the changes in this PR. It may need to be tested before being merged.** 

